### PR TITLE
Add #27 shared capabilities for mounting extra directories.

### DIFF
--- a/incubator/foundry-vtt/Chart.yaml
+++ b/incubator/foundry-vtt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: foundry-vtt
 description: Foundry Virtual Tabletop
 type: application
-version: 0.2.5
+version: 0.2.6
 appVersion: 0.7.9
 keywords:
 - game

--- a/incubator/foundry-vtt/templates/deployment.yaml
+++ b/incubator/foundry-vtt/templates/deployment.yaml
@@ -183,6 +183,13 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /data
+      {{- if eq .Values.persistence.shared.enabled true }}
+        {{- range $i, $mount := .Values.persistence.shared.mounts }}
+        - name: {{ printf "%s-%s" "shared" ($i|toString) }}
+          mountPath: {{ printf "%s%s" "/data/Data" $mount.containerPath }}
+          readOnly: {{ $mount.readOnly }}
+        {{- end }}
+      {{- end }}
       {{- if eq .Values.foundryvtt.s3.awsConfig "file" }}
         - name: secret-aws
           mountPath: "/etc/secretaws/"
@@ -216,4 +223,17 @@ spec:
           claimName: {{ template "foundry-vtt.fullname" . }}
     {{- else }}
         emptyDir: {}
+    {{- end }}
+    {{- if eq .Values.persistence.shared.enabled true }}
+      {{- range $i, $mount := .Values.persistence.shared.mounts }}
+      - name: {{ printf "%s-%s" "shared" ($i|toString) }}
+        {{ if eq $mount.type "bind" }}
+        hostPath:
+          path: {{ $mount.hostPath }}
+          type: Directory
+        {{ else if eq $mount.type "pvc" }}
+        persistentVolumeClaim:
+          claimName: {{ $mount.claimName }}
+        {{ end }}
+      {{- end }}
     {{- end }}

--- a/incubator/foundry-vtt/values.yaml
+++ b/incubator/foundry-vtt/values.yaml
@@ -84,6 +84,24 @@ persistence:
     enabled: false
     Size: 5Gi
 
+  shared:
+    # Enable tha shared mount for a NFS file system or a shared bind point with for
+    # sharing assets between multiple game instances when not using s3.
+    enabled: false
+    mounts:
+    ## containerPath: is relative to the /data/Data
+    ## type: bind or pvc
+    ## hostpath: only used for bind mount
+    ## readOnly: enable read only directories
+    ## clainName: to be used mainly with NFS CSI PV/PVC
+    # - containerPath: "/shared"
+    #   type: bind
+    #   hostPath: /files/assets
+    #   readOnly: true
+    # - containerPath: "/files/assets"
+    #   type: pvc
+    #   claimName: "pvc-files"
+
 # felddy/foundryvtt-docker container extra customizations.
 container:
   ## Set a path to cache downloads of the Foundry distribution archive and speed up subsequent container startups. The path should be in /data or another persistent mount point in the container. e.g.; /data/cache


### PR DESCRIPTION
  * This adds the capability of multiple directories with RW/RO
throught bind/hostPath or PVC for NFS.

  * The PVC for the NFS at this moment is not covered on the Chart
creation, it must be done outside.

  * As this feature is tarteting to share content the idea is that the
PVC for this was created priviously and would have the content to be
shared, so this chart will only mount that 1,n desired content
providor.