### PR TITLE
Deprecate K8S 1.18-, Upgrade Ingress and bump to Foundry 0.7.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 .mypy_cache
 .pytest_cache
 .python-version
+.envrc
 *-mine.*
 *.egg-info
 *.tgz

--- a/incubator/foundry-vtt/Chart.yaml
+++ b/incubator/foundry-vtt/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: foundry-vtt
 description: Foundry Virtual Tabletop
 type: application
-version: 0.2.6
-appVersion: 0.7.9
+version: 0.2.7
+appVersion: 0.7.10
 keywords:
 - game
 - server

--- a/incubator/foundry-vtt/README.md
+++ b/incubator/foundry-vtt/README.md
@@ -1,7 +1,7 @@
 # Foundry VTT
 
 <!-- BADGES/ -->
-[![FoundryVTT Version: v0.7.9](https://img.shields.io/badge/foundry-v0.7.9-brightgreen?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IArs4c6QAAAIRlWElmTU0AKgAAAAgABQESAAMAAAABAAEAAAEaAAUAAAABAAAASgEbAAUAAAABAAAAUgEoAAMAAAABAAIAAIdpAAQAAAABAAAAWgAAAAAAAABIAAAAAQAAAEgAAAABAAOgAQADAAAAAQABAACgAgAEAAAAAQAAAA6gAwAEAAAAAQAAAA4AAAAATspU+QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAAiFJREFUKBVVks1rE1EUxc+d5tO0prZVSZsUhSBIPyC02ooWurJ0I7rQlRvdC/4N4h9gt7pyoRTswpWgILgQBIOIiC340VhbpC0Ek85MGmPmXc+baWpNGJg77/7uOffeB+z9FHB0FrH9eLwwqpOF0f34KrpsTicW+6L8KE8QhO/n8n1IOgtQHYZA+a/Ai9+Wd6v1g7liq5A2OjKSQNa9hkO4hAzOIylf6CHALk6hoWXsylPkfjyyApaJhVCxmERy5zLSuI7D8h1H5BWht1aBhS6wdI3pN7GabyuyS4JPrchzujmNjDxAVrrRL2PoxRSGxOfjssgEjkkJvVJBWu6h5M7YenvDoOO0OgicD4TPIKWbBG6xvwTaKCMwSU7hKxK6gt8mbsFIMaF5iDyjUg6iPnqc58higCr9fD4iTvWMziAmK2g73f/AADVWX0YXrlChirgOcqL3WXYBYpTfUuxzjkW30dI1C0ZW1RnjMopo4C56MIs6CgQrMER2cJoz9zjdO2iz17g2yZUjqzHWbuA4/ugiEz7DVRe/aLxmcvDQ5Cq+oWGWeDbAgiETXgArrVOFGzR0EkclxrVMcpfLgFThY5roe2yz95ZZkzcbj22+w2VG8Pz6Q/b5Gr6uM9mw04uo6ll4tOlhE8a8xNzGYihCJoT+u3I4kUIp6OM0X9CHHds8frbqsrXlh9CB62nj8L5a9Y4DHR/K68TgcHhoz607Qp34L72X0rdSdM+vAAAAAElFTkSuQmCC)](https://foundryvtt.com/releases/0.7.9)
+[![FoundryVTT Version: v0.7.10](https://img.shields.io/badge/foundry-v0.7.10-brightgreen?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAAAXNSR0IArs4c6QAAAIRlWElmTU0AKgAAAAgABQESAAMAAAABAAEAAAEaAAUAAAABAAAASgEbAAUAAAABAAAAUgEoAAMAAAABAAIAAIdpAAQAAAABAAAAWgAAAAAAAABIAAAAAQAAAEgAAAABAAOgAQADAAAAAQABAACgAgAEAAAAAQAAAA6gAwAEAAAAAQAAAA4AAAAATspU+QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAVlpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IlhNUCBDb3JlIDUuNC4wIj4KICAgPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4KICAgICAgPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIKICAgICAgICAgICAgeG1sbnM6dGlmZj0iaHR0cDovL25zLmFkb2JlLmNvbS90aWZmLzEuMC8iPgogICAgICAgICA8dGlmZjpPcmllbnRhdGlvbj4xPC90aWZmOk9yaWVudGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KTMInWQAAAiFJREFUKBVVks1rE1EUxc+d5tO0prZVSZsUhSBIPyC02ooWurJ0I7rQlRvdC/4N4h9gt7pyoRTswpWgILgQBIOIiC340VhbpC0Ek85MGmPmXc+baWpNGJg77/7uOffeB+z9FHB0FrH9eLwwqpOF0f34KrpsTicW+6L8KE8QhO/n8n1IOgtQHYZA+a/Ai9+Wd6v1g7liq5A2OjKSQNa9hkO4hAzOIylf6CHALk6hoWXsylPkfjyyApaJhVCxmERy5zLSuI7D8h1H5BWht1aBhS6wdI3pN7GabyuyS4JPrchzujmNjDxAVrrRL2PoxRSGxOfjssgEjkkJvVJBWu6h5M7YenvDoOO0OgicD4TPIKWbBG6xvwTaKCMwSU7hKxK6gt8mbsFIMaF5iDyjUg6iPnqc58higCr9fD4iTvWMziAmK2g73f/AADVWX0YXrlChirgOcqL3WXYBYpTfUuxzjkW30dI1C0ZW1RnjMopo4C56MIs6CgQrMER2cJoz9zjdO2iz17g2yZUjqzHWbuA4/ugiEz7DVRe/aLxmcvDQ5Cq+oWGWeDbAgiETXgArrVOFGzR0EkclxrVMcpfLgFThY5roe2yz95ZZkzcbj22+w2VG8Pz6Q/b5Gr6uM9mw04uo6ll4tOlhE8a8xNzGYihCJoT+u3I4kUIp6OM0X9CHHds8frbqsrXlh9CB62nj8L5a9Y4DHR/K68TgcHhoz607Qp34L72X0rdSdM+vAAAAAElFTkSuQmCC)](https://foundryvtt.com/releases/0.7.10)
 [![GitHub Charts](https://github.com/hugoprudente/charts/workflows/Lint%20and%20Test%20Charts/badge.svg)](https://github.com/hugoprudente/charts/actions/)
 [![Patreon](https://img.shields.io/badge/patreon-donate-yellow.svg)](https://patreon.com/nerdweekoficial)
 [![GitHub license](https://img.shields.io/github/license/hugoprudente/charts)](https://github.com/hugoprudente/charts/blob/master/LICENSE)
@@ -17,7 +17,7 @@ minutes using this chart and Felddy [foundryvtt-docker](https://github.com/feldd
 ## Prerequisites
 
 - 512 MB of RAM
-- Kubernetes 1.4+ with Beta APIs enabled
+- Kubernetes 1.19+
 - PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
@@ -109,7 +109,7 @@ evaluated in the following order of precedence:
 #### Pre-cached distribution variable ####
 
 A distribution can be downloaded and placed into a cache directory.  The
-distribution's name must be of the form: `foundryvtt-0.7.9.zip`
+distribution's name must be of the form: `foundryvtt-0.7.10.zip`
 
 | Name             | Purpose  |
 |------------------|----------|
@@ -148,7 +148,7 @@ distribution's name must be of the form: `foundryvtt-0.7.9.zip`
 | foundryvtt.turnConfigs | An array of TURN configurations in JSON format.  See: [Using a Custom Relay Server](https://foundryvtt.com/article/audio-video/#custom).  To disable the internal relay server comment the paramenter. |  |
 | foundryvtt.turnMaxPort | Sets the maximum UDP port used by the internal [TURN relay server](https://foundryvtt.com/article/audio-video/).  This value must be greater than `49152`.  _Note: To use the internal relay server its ports must be published._ | |
 | foundryvtt.upnp | Allow Universal Plug and Play to automatically request port forwarding for the Foundry VTT port to your local network address. | false |
-| foundryvtt.version | Version of Foundry Virtual Tabletop to install. | 0.7.9 |
+| foundryvtt.version | Version of Foundry Virtual Tabletop to install. | 0.7.10 |
 | foundryvtt.world | The world startup at system start. | null |
 
 ## Persistence

--- a/incubator/foundry-vtt/templates/ingress-contour.yaml
+++ b/incubator/foundry-vtt/templates/ingress-contour.yaml
@@ -9,23 +9,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-# {{- if .Values.ingress.configurationSnippet }}
-#     nginx.ingress.kubernetes.io/configuration-snippet: |
-#       {{- template "configurationSnippet" . }}
-# {{- end }}
-# {{- if eq .Values.tls "external" }}
-#     nginx.ingress.kubernetes.io/ssl-redirect: "false" # turn off ssl redirect for external.
-# {{- else }}
-#   {{- if ne .Values.ingress.tls.source "secret" }}
-#     {{- $certmanagerVer :=  split "." .Values.certmanager.version -}}
-#     {{- if or (.Capabilities.APIVersions.Has "cert-manager.io/v1alpha2") (and (eq (int $certmanagerVer._0) 0) (ge (int $certmanagerVer._1) 11)) }}
-#     cert-manager.io/issuer: {{ template "foundry-vtt.fullname" . }}
-#     cert-manager.io/issuer-kind: Issuer
-#     {{- else if or (.Capabilities.APIVersions.Has "certmanager.k8s.io/v1alpha1") (and (eq (int $certmanagerVer._0) 0) (lt (int $certmanagerVer._1) 11)) }}
-#     certmanager.k8s.io/issuer: {{ template "foundry-vtt.fullname" . }}
-#     {{- end }}
-#   {{- end }}
-# {{- end }}
 {{- if .Values.ingress.extraAnnotations }}
 {{ toYaml .Values.ingress.extraAnnotations | indent 4 }}
 {{- end }}
@@ -53,7 +36,7 @@ spec:
         - name: {{ template "foundry-vtt.fullname" . }}
           port: 80
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -66,9 +49,13 @@ spec:
   - host: {{ .Values.ingress.hostname }}
     http:
       paths:
-      - backend:
-          serviceName: {{ template "foundry-vtt.fullname" . }}
-          servicePort: 80
+       - pathType: Prefix
+         path: "/"
+         backend:
+           service:
+             name: {{ template "foundry-vtt.fullname" . }}
+             port:
+               number: 80
   tls:
   - hosts:
     - {{ .Values.ingress.hostname }}

--- a/incubator/foundry-vtt/templates/ingress-nginx.yaml
+++ b/incubator/foundry-vtt/templates/ingress-nginx.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq .Values.ingress.enabled true) (eq .Values.ingress.class "nginx") }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "foundry-vtt.fullname" . }}
@@ -34,9 +34,13 @@ spec:
   - host: {{ .Values.ingress.hostname }}
     http:
       paths:
-      - backend:
-          serviceName: {{ template "foundry-vtt.fullname" . }}
-          servicePort: 80
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: {{ template "foundry-vtt.fullname" . }}
+            port:
+              number: 80
 {{- if eq .Values.tls "ingress" }}
   tls:
   - hosts:


### PR DESCRIPTION
* K8S 1.18.x is already deprecated and the 1.19 end-of-life is in
  2021-10-28. Deprecating the 1.18 ensures that the Chart is valid
  for versions 1.19+
* Due to the deprecation Ingress was updated to match the new pattern
* Upgrade Foundry to latest 0.7.x release.