### PR TITLE
feat: make replica configurable and ingressClassName

### DIFF
--- a/incubator/foundry-vtt/templates/deployment.yaml
+++ b/incubator/foundry-vtt/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   strategy:
     type: Recreate
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       {{- include "foundry-vtt.selectorLabels" . | nindent 6 }}

--- a/incubator/foundry-vtt/templates/ingress-nginx.yaml
+++ b/incubator/foundry-vtt/templates/ingress-nginx.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.ingress.enabled true) (eq .Values.ingress.class "nginx") }}
+{{- if and (eq .Values.ingress.enabled true) (ne .Values.ingress.class "contour") }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -30,6 +30,7 @@ metadata:
 {{ toYaml .Values.ingress.extraAnnotations | indent 4 }}
 {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.class}}
   rules:
   - host: {{ .Values.ingress.hostname }}
     http:

--- a/incubator/foundry-vtt/values.yaml
+++ b/incubator/foundry-vtt/values.yaml
@@ -2,6 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+replicas: 1
+
 cloudProviders:
   aws:
     accountId: ACCOUNTID


### PR DESCRIPTION
Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

Fixes #49 

Hi,

This PR makes the `replica` property configurable and adds `ingressClassName` to the ingress-nginx.

Looking for your feedback.